### PR TITLE
Fix route configuration issue in case of /32 IP

### DIFF
--- a/docker/agent/configure.sh
+++ b/docker/agent/configure.sh
@@ -80,5 +80,8 @@ if [[ $VROUTER_PHYSICAL_INTERFACE != $VIRTUAL_HOST_INTERFACE ]]; then
     ip address delete $VIRTUAL_HOST_INTERFACE_IP_WITH_MASK dev $PHYSICAL_INTERFACE
     ip address add $VIRTUAL_HOST_INTERFACE_IP_WITH_MASK dev $VIRTUAL_HOST_INTERFACE
     ip link set dev $VIRTUAL_HOST_INTERFACE up
-    ip route add default via $NODE_GATEWAY
+    if [[ ${VIRTUAL_HOST_INTERFACE_IP_WITH_MASK#*/} -eq 32 ]]; then
+        ip route add unicast $NODE_GATEWAY dev $VIRTUAL_HOST_INTERFACE scope link
+    fi
+    ip route add default via $NODE_GATEWAY dev $VIRTUAL_HOST_INTERFACE
 fi


### PR DESCRIPTION
In some cloud systems like google cloud, the VM get an IP address with
/32 subnet mask in which case current agent code breaking the VM
connectivity because the default gateway that supposed to configure
there is in not in that server's network (because of /32 IP).

So in that case, it need to add the gateway IP as linklocal before
adding default gateway. This change should fix above mentioned issue.
