### PR TITLE
Added easy to use targets to make specific containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ CONTRAIL_ANSIBLE = contrail-ansible
 
 all: $(CONTAINER_TARS)
 
+$(CONTAINERS): $(CONTAINER_TARS)
+	@touch $@
 
 $(CONTAINER_TARS): prep
 	$(eval CONTRAIL_BUILD_ARGS := --build-arg CONTRAIL_REPO_URL=http://$(CONTRAIL_REPO_IP):$(CONTRAIL_REPO_PORT) )


### PR DESCRIPTION
This change will add easy to use make targets so that one can use
make <container name>  to build only specific container - e.g the
command "make controller" (along with appropriate variables) will build
controller container.
