### PR TITLE
Support building analytics on ubuntu:14.04.5

### DIFF
--- a/docker/analytics/Dockerfile
+++ b/docker/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM hkumar/ubuntu-14.04.2:latest
+FROM ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_REPO_URL
 ARG CONTRAIL_ANSIBLE_TAR
@@ -12,7 +12,7 @@ RUN sed -i "1ideb $CONTRAIL_REPO_URL ./" /etc/apt/sources.list
 RUN var1=$(echo $CONTRAIL_REPO_URL | sed -r 's#http[s]?://([[:digit:]\.]+):.*#\1#') ; \
     echo "Package: *\nPin: origin \"$var1\"\nPin-Priority: 1001" > /etc/apt/preferences
 RUN echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/99allowunauth
-RUN $apt_install software-properties-common && \
+RUN apt-get update -qy && $apt_install software-properties-common && \
     apt-add-repository -y ppa:ansible/ansible
 RUN apt-get update -qy && \
     $apt_install $PACKAGES_ANSIBLE && \

--- a/docker/analytics/entrypoint.sh
+++ b/docker/analytics/entrypoint.sh
@@ -58,7 +58,7 @@ $DAEMON $DAEMON_OPTS 2>&1 | tee -a $LOG &
 child=$!
 
 cd /contrail-ansible/playbooks/
-ansible-playbook -i inventory/$ANSIBLE_INVENTORY -t service contrail_analyticsdb.yml
+ansible-playbook -i inventory/$ANSIBLE_INVENTORY -t service contrail_analytics.yml
 
 # Register analytics in config
 retry /usr/share/contrail-utils/provision_analytics_node.py --api_server_ip $API_SERVER_IP \


### PR DESCRIPTION
Enabling force on apt install as it may needed to degrade some
packages which would need force-yes.

This reduce image size by about 200 MB.