### PR TITLE
Support building agent on ubuntu:14.04.5

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM hkumar/ubuntu-14.04.2:latest
+FROM ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_INSTALL_PACKAGE_URL
 ARG CONTRAIL_REPO_URL


### PR DESCRIPTION
Enabling force on apt install as it may needed to degrade some
packages which would need force-yes.

This reduce image size by about 300 MB.