### PR TITLE
Agent cctl build

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,27 +1,29 @@
 FROM ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
-ARG CONTRAIL_INSTALL_PACKAGE_URL
 ARG CONTRAIL_REPO_URL
 ARG CONTRAIL_ANSIBLE_TAR
-ARG ENTRY_POINT=docker_entrypoint.sh
-ARG SSHPASS
 ARG DEBIAN_FRONTEND=noninteractive
 ARG apt_install="apt-get install -yq --force-yes --no-install-recommends --no-install-suggests "
-ARG ANSIBLE_INVENTORY="all-in-one"
-ARG PACKAGES_CONTRAIL_AGENT="contrail-lib contrail-utils contrail-vrouter-utils python-contrail-vrouter-api \
-    python-opencontrail-vrouter-netns contrail-vrouter-agent contrail-vrouter-init contrail-nodemgr crudini jq \
-    curl python-yaml"
-
+ENV ANSIBLE_INVENTORY="all-in-one"
+ARG PACKAGES_ANSIBLE="ansible"
 RUN sed -i "1ideb $CONTRAIL_REPO_URL ./" /etc/apt/sources.list
 RUN var1=$(echo $CONTRAIL_REPO_URL | sed -r 's#http[s]?://([[:digit:]\.]+):.*#\1#') ; \
     echo "Package: *\nPin: origin \"$var1\"\nPin-Priority: 1001" > /etc/apt/preferences
 RUN echo "APT::Get::AllowUnauthenticated \"true\";" > /etc/apt/apt.conf.d/99allowunauth
+RUN apt-get update -qy && $apt_install software-properties-common && \
+    apt-add-repository -y ppa:ansible/ansible
 RUN apt-get update -qy && \
-    $apt_install $PACKAGES_CONTRAIL_AGENT && \
+    $apt_install $PACKAGES_ANSIBLE && \
     apt-get autoremove -yq  &&\
     rm -fr /usr/share/doc/* /usr/share/man/*
-RUN cp -rf /usr/src/ /usr/src.orig/
-COPY *.sh *.j2 /
+ADD $CONTRAIL_ANSIBLE_TAR /
+RUN $apt_install python-configparser
+COPY python-contrailctl /python-contrailctl
+RUN cd /python-contrailctl/; python setup.py install
+RUN contrailctl config sync -c agent -F -t install
+RUN mkdir -p /etc/contrailctl/
 EXPOSE 8081 8086
+RUN cp -rf /usr/src/ /usr/src.orig/
+COPY *.sh /
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT /entrypoint.sh

--- a/tools/python-contrailctl/contrailctl/cmd.py
+++ b/tools/python-contrailctl/contrailctl/cmd.py
@@ -2,8 +2,7 @@ import argparse
 import yaml
 import sys
 from contrailctl.config import Configurator
-from contrailctl.map import CONTROLLER_PARAM_MAP, ANALYTICSDB_PARAM_MAP,\
-        ANALYTICS_PARAM_MAP, LB_PARAM_MAP
+from contrailctl.map import *
 from contrailctl.runner import Runner
 
 
@@ -17,13 +16,15 @@ class ConfigManager(object):
         "analyticsdb": ANALYTICSDB_PARAM_MAP,
         "analytics": ANALYTICS_PARAM_MAP,
         "lb": LB_PARAM_MAP,
+        "agent": AGENT_PARAM_MAP,
     }
 
     PLAYBOOKS = dict(
         controller="contrail_controller.yml",
         analytics="contrail_analytics.yml",
         analyticsdb="contrail_analyticsdb.yml",
-        lb="contrail_lb.yml"
+        lb="contrail_lb.yml",
+        agent="contrail_agent.yml",
     )
 
     def __init__(self, config_file, component):

--- a/tools/python-contrailctl/contrailctl/map.py
+++ b/tools/python-contrailctl/contrailctl/map.py
@@ -69,3 +69,9 @@ ANALYTICSDB_PARAM_MAP = dict(
         controller_ip="controller_ip"
     ),
 )
+
+AGENT_PARAM_MAP = dict(
+    GLOBAL=dict(
+        controller_ip="controller_ip"
+    ),
+)


### PR DESCRIPTION
Agent container to use ansible/contrailctl to build itself
    
This patch add support to use contrailctl + ansible to build vrouter
agent container.