### PR TITLE
Install crudini which is required for non-ansible setup code

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -25,5 +25,6 @@ RUN mkdir -p /etc/contrailctl/
 EXPOSE 8081 8086
 RUN cp -rf /usr/src/ /usr/src.orig/
 COPY *.sh /
+RUN $apt_install crudini
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT /entrypoint.sh


### PR DESCRIPTION
Until completely migrated to ansible code, this is required for agent
container to work.