### PR TITLE
Used known to work ubuntu and centos base image

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.5
+FROM hkumar/ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_REPO_URL
 ARG CONTRAIL_ANSIBLE_TAR

--- a/docker/analytics/Dockerfile
+++ b/docker/analytics/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.5
+FROM hkumar/ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_REPO_URL
 ARG CONTRAIL_ANSIBLE_TAR

--- a/docker/analyticsdb/Dockerfile
+++ b/docker/analyticsdb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.5
+FROM hkumar/ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_REPO_URL
 ARG CONTRAIL_ANSIBLE_TAR

--- a/docker/contrail_repo/Dockerfile
+++ b/docker/contrail_repo/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM hkumarmk/ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_INSTALL_PACKAGE_TAR_URL
 ARG http_proxy

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.5
+FROM hkumar/ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_REPO_URL
 ARG CONTRAIL_ANSIBLE_TAR

--- a/docker/kube-manager/Dockerfile
+++ b/docker/kube-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.5
+FROM hkumar/ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_REPO_URL
 ARG CONTRAIL_ANSIBLE_TAR

--- a/docker/lb/Dockerfile
+++ b/docker/lb/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04.5
+FROM hkumar/ubuntu:14.04.5
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG ENTRY_POINT=docker_entrypoint.sh
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/vrouter_module_compiler/redhat/Dockerfile
+++ b/docker/vrouter_module_compiler/redhat/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.1.1503
+FROM hkumar/centos:7.1.1503
 MAINTAINER Juniper Contrail <contrail@juniper.net>
 ARG CONTRAIL_VROUTER_SOURCE_RPM_URL
 ARG ENTRY_POINT=entrypoint.sh


### PR DESCRIPTION
    I have saved a snapshot of ubuntu-14.04.5 and centos-7.1.1503 docker
    base images in dockerhub so we can use them reliably. So that we will
    not get into problems after ubuntu/centos push any updates to existing
    image which break our build.
    
    Recently ubuntu updated their packages and docker base image which cause
    package conflicts for us. Using saved snapshot of docker base image
    would avoid this kind of issues.