### PR TITLE
Fix issue with 'make push' of container apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,11 +172,11 @@ push: $(CONTAINER_TARS)
 ifdef CONTAINER_REGISTRY
 		@for i in $(CONTAINERS); do\
 			CONTAINER_NAME=contrail-$$i;\
-			CONTAINER_TAG=$$(docker images | grep "^$$CONTAINER_NAME " | awk '{print $$3}');\
+			CONTAINER_TAG=$$(docker images | grep "^$$CONTAINER_NAME-$$OS " | awk '{print $$3}');\
 			CONTAINER_REG_NAME=$$CONTAINER_REGISTRY/$$CONTAINER_NAME-$$OS:$$CONTRAIL_VERSION;\
-			echo "Tagging container $$CONTAINER_REG_NAME";\
+			echo "Tagging container: docker tag $$CONTAINER_TAG $$CONTAINER_REG_NAME";\
 			docker tag $$CONTAINER_TAG $$CONTAINER_REG_NAME;\
-			echo "Pushing container $$CONTAINER_REG_NAME";\
+			echo "Pushing container: docker push $$CONTAINER_REG_NAME";\
 			docker push $$CONTAINER_REG_NAME;\
 		done
 else


### PR DESCRIPTION
With addition of $OS qualifier to container names, a grep was failing
to find the docker container to be registered and pushed.

As well as fixing the grep, show the actual 'docker tag' and 'docker
push' commands being invoked.