### PR TITLE
Remove upstream apt sources for trusty containers

### DIFF
--- a/docker/agent/u14.04/Dockerfile
+++ b/docker/agent/u14.04/Dockerfile
@@ -12,6 +12,7 @@ ARG PACKAGES_ANSIBLE="ansible python-configparser"
 ARG CONTRAIL_REPO_MIRROR_SNAPSHOT=12032016
 COPY contrail-ubuntu-mirror.key /
 RUN apt-key add /contrail-ubuntu-mirror.key;\
+    echo > /etc/apt/sources.list ;\
     echo "deb $CONTRAIL_REPO_URL ./" > /etc/apt/sources.list.d/contrail-local.list;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty main universe" > /etc/apt/sources.list.d/trusty.list ;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty-updates/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty-updates main universe" > /etc/apt/sources.list.d/trusty-updates.list ;\

--- a/docker/analytics/u14.04/Dockerfile
+++ b/docker/analytics/u14.04/Dockerfile
@@ -12,6 +12,7 @@ ARG PACKAGES_ANSIBLE="ansible python-configparser"
 ARG CONTRAIL_REPO_MIRROR_SNAPSHOT=12032016
 COPY contrail-ubuntu-mirror.key /
 RUN apt-key add /contrail-ubuntu-mirror.key;\
+    echo > /etc/apt/sources.list ;\
     echo "deb $CONTRAIL_REPO_URL ./" > /etc/apt/sources.list.d/contrail-local.list;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty main universe" > /etc/apt/sources.list.d/trusty.list ;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty-updates/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty-updates main universe" > /etc/apt/sources.list.d/trusty-updates.list ;\

--- a/docker/analyticsdb/u14.04/Dockerfile
+++ b/docker/analyticsdb/u14.04/Dockerfile
@@ -12,6 +12,7 @@ ARG PACKAGES_ANSIBLE="ansible python-configparser"
 ARG CONTRAIL_REPO_MIRROR_SNAPSHOT=12032016
 COPY contrail-ubuntu-mirror.key /
 RUN apt-key add /contrail-ubuntu-mirror.key;\
+    echo > /etc/apt/sources.list ;\
     echo "deb $CONTRAIL_REPO_URL ./" > /etc/apt/sources.list.d/contrail-local.list;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty main universe" > /etc/apt/sources.list.d/trusty.list ;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty-updates/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty-updates main universe" > /etc/apt/sources.list.d/trusty-updates.list ;\

--- a/docker/controller/u14.04/Dockerfile
+++ b/docker/controller/u14.04/Dockerfile
@@ -12,6 +12,7 @@ ARG PACKAGES_ANSIBLE="ansible python-configparser"
 ARG CONTRAIL_REPO_MIRROR_SNAPSHOT=12032016
 COPY contrail-ubuntu-mirror.key /
 RUN apt-key add /contrail-ubuntu-mirror.key;\
+    echo > /etc/apt/sources.list ;\
     echo "deb $CONTRAIL_REPO_URL ./" > /etc/apt/sources.list.d/contrail-local.list;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty main universe" > /etc/apt/sources.list.d/trusty.list ;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty-updates/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty-updates main universe" > /etc/apt/sources.list.d/trusty-updates.list ;\

--- a/docker/kube-manager/u14.04/Dockerfile
+++ b/docker/kube-manager/u14.04/Dockerfile
@@ -12,6 +12,7 @@ ARG PACKAGES_ANSIBLE="ansible python-configparser"
 ARG CONTRAIL_REPO_MIRROR_SNAPSHOT=12032016
 COPY contrail-ubuntu-mirror.key /
 RUN apt-key add /contrail-ubuntu-mirror.key;\
+    echo > /etc/apt/sources.list ;\
     echo "deb $CONTRAIL_REPO_URL ./" > /etc/apt/sources.list.d/contrail-local.list;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty main universe" > /etc/apt/sources.list.d/trusty.list ;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty-updates/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty-updates main universe" > /etc/apt/sources.list.d/trusty-updates.list ;\

--- a/docker/lb/u14.04/Dockerfile
+++ b/docker/lb/u14.04/Dockerfile
@@ -12,6 +12,7 @@ ARG PACKAGES_ANSIBLE="ansible python-configparser"
 ARG CONTRAIL_REPO_MIRROR_SNAPSHOT=12032016
 COPY contrail-ubuntu-mirror.key /
 RUN apt-key add /contrail-ubuntu-mirror.key;\
+    echo > /etc/apt/sources.list ;\
     echo "deb $CONTRAIL_REPO_URL ./" > /etc/apt/sources.list.d/contrail-local.list;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty main universe" > /etc/apt/sources.list.d/trusty.list ;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty-updates/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty-updates main universe" > /etc/apt/sources.list.d/trusty-updates.list ;\

--- a/docker/mesos-manager/u14.04/Dockerfile
+++ b/docker/mesos-manager/u14.04/Dockerfile
@@ -12,6 +12,7 @@ ARG PACKAGES_ANSIBLE="ansible python-configparser"
 ARG CONTRAIL_REPO_MIRROR_SNAPSHOT=12032016
 COPY contrail-ubuntu-mirror.key /
 RUN apt-key add /contrail-ubuntu-mirror.key;\
+    echo > /etc/apt/sources.list ;\
     echo "deb $CONTRAIL_REPO_URL ./" > /etc/apt/sources.list.d/contrail-local.list;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty main universe" > /etc/apt/sources.list.d/trusty.list ;\
     echo "deb [arch=amd64] http://10.84.34.201:8080/trusty-updates/$CONTRAIL_REPO_MIRROR_SNAPSHOT/ trusty-updates main universe" > /etc/apt/sources.list.d/trusty-updates.list ;\


### PR DESCRIPTION
Now only external repo using within ubuntu trusty container is for ansible.
Other than that, it use contrail internal mirror and a repo that is
created with contrail-install-package tgz file.