### PR TITLE
No need to run ansible-galaxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,6 @@ endif
 		cd $(CONTRAIL_ANSIBLE) ;\
 		git checkout $(CONTRAIL_ANSIBLE_REF) ;\
 		git reset --hard; \
-		ansible-galaxy install -r requirements.yml -p playbooks/roles/ ;\
 		rm -fr .git* ;\
 		cd .. ; \
 		echo "Saving to $(CONTRAIL_ANSIBLE_TAR)";\


### PR DESCRIPTION
contrail-ansible included all dependency modules so no need to get it
from ansible galaxy now. So removing that step.