### PR TITLE
Support Contrail on Redhat Dockers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ ifneq (,$(filter c7.1 c7.2,$(OS)))
 	export CONTAINERS = vrouter-compiler
 endif
 
+ifneq (,$(filter centos redhat,$(OS)))
+	export CONTRAIL_REPO_CONTAINER = contrail-repo-$(OS)
+	export CONTRAIL_REPO_CONTAINER_TAR = $(CONTRAIL_REPO_CONTAINER)-$(CONTRAIL_VERSION).tar.gz
+endif
+
 CONTRAIL_ANSIBLE_TAR = contrail-ansible-$(CONTRAIL_VERSION).tar.gz
 CONTRAIL_ANSIBLE_REPO = "git@github.com:Juniper/contrail-ansible.git"
 CONTRAIL_ANSIBLE_REF = "master"
@@ -115,6 +120,8 @@ contrail-repo:  $(CONTRAIL_REPO_CONTAINER_TAR)
 $(CONTRAIL_BASE_TAR): contrail-ansible contrail-repo
 	$(eval CONTRAIL_BUILD_ARGS := )
 	$(eval CONTRAIL_BUILD_ARGS +=  --build-arg CONTRAIL_ANSIBLE_TAR=$(CONTRAIL_ANSIBLE_TAR) )
+	$(eval CONTRAIL_BUILD_ARGS +=  --build-arg CONTRAIL_VERSION=$(CONTRAIL_VERSION) )
+	$(eval CONTRAIL_BUILD_ARGS +=  --build-arg OS=$(OS) )
 	$(eval CONTRAIL_BUILD_ARGS += $(http_proxy_build_arg))
 	$(eval CONTRAIL_BUILD_ARGS += $(repo_snapshot_build_arg))
 	$(eval TEMP := $(shell mktemp -d))
@@ -160,6 +167,9 @@ endif
 
 	$(eval CONTRAIL_REPO_BUILD_ARGS := --build-arg CONTRAIL_INSTALL_PACKAGE_TAR_URL=$(CONTRAIL_INSTALL_PACKAGE_TAR_URL))
 	$(eval CONTRAIL_REPO_BUILD_ARGS +=  $(http_proxy_build_arg))
+	$(eval CONTRAIL_REPO_BUILD_ARGS +=  --build-arg CONTRAIL_VERSION=$(CONTRAIL_VERSION) )
+	$(eval CONTRAIL_REPO_BUILD_ARGS +=  --build-arg CONTRAIL_REPO_PORT=$(CONTRAIL_REPO_PORT) )
+	$(eval CONTRAIL_REPO_BUILD_ARGS +=  --build-arg OS=$(OS) )
 
 ifdef SSHPASS
 	$(eval CONTRAIL_REPO_BUILD_ARGS += --build-arg SSHPASS=$(SSHPASS) )

--- a/docker/agent/redhat/Dockerfile.j2
+++ b/docker/agent/redhat/Dockerfile.j2
@@ -1,0 +1,19 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-agent-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Vrouter Agent" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c agent -F -t package
+RUN contrailctl config sync -c agent -F -t install
+EXPOSE 8085 9090
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass

--- a/docker/agent/redhat/redhat.repo.empty
+++ b/docker/agent/redhat/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/agent/redhat7/Dockerfile.j2
+++ b/docker/agent/redhat7/Dockerfile.j2
@@ -1,0 +1,19 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-agent-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Vrouter Agent" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c agent -F -t package
+RUN contrailctl config sync -c agent -F -t install
+EXPOSE 8085 9090
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass

--- a/docker/agent/redhat7/redhat.repo.empty
+++ b/docker/agent/redhat7/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/analytics/redhat/Dockerfile.j2
+++ b/docker/analytics/redhat/Dockerfile.j2
@@ -1,0 +1,20 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-analytics-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Analytics" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c analytics -F -t package
+RUN contrailctl config sync -c analytics -F -t install
+EXPOSE 8081 8086
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass
+

--- a/docker/analytics/redhat/redhat.repo.empty
+++ b/docker/analytics/redhat/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/analytics/redhat7/Dockerfile.j2
+++ b/docker/analytics/redhat7/Dockerfile.j2
@@ -1,0 +1,20 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-analytics-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Analytics" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c analytics -F -t package
+RUN contrailctl config sync -c analytics -F -t install
+EXPOSE 8081 8086
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass
+

--- a/docker/analytics/redhat7/redhat.repo.empty
+++ b/docker/analytics/redhat7/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/analyticsdb/redhat/Dockerfile.j2
+++ b/docker/analyticsdb/redhat/Dockerfile.j2
@@ -1,0 +1,20 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-analyticsdb-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail AnalyticsDB" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c analyticsdb -F -t package
+RUN contrailctl config sync -c analyticsdb -F -t install
+EXPOSE 9141 9161
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass
+

--- a/docker/analyticsdb/redhat/redhat.repo.empty
+++ b/docker/analyticsdb/redhat/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/analyticsdb/redhat7/Dockerfile.j2
+++ b/docker/analyticsdb/redhat7/Dockerfile.j2
@@ -1,0 +1,20 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-analyticsdb-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail AnalyticsDB" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c analyticsdb -F -t package
+RUN contrailctl config sync -c analyticsdb -F -t install
+EXPOSE 9141 9161
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass
+

--- a/docker/analyticsdb/redhat7/redhat.repo.empty
+++ b/docker/analyticsdb/redhat7/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/contrail-base/redhat/Dockerfile
+++ b/docker/contrail-base/redhat/Dockerfile
@@ -1,0 +1,48 @@
+FROM contrail-base-os-images/rhel-7.2
+MAINTAINER Juniper Contrail <contrail@juniper.net>
+ARG CONTRAIL_REPO_URL
+ARG CONTRAIL_ANSIBLE_TAR
+ARG CONTRAIL_VERSION
+ARG OS
+ENV ANSIBLE_INVENTORY="all-in-one"
+ARG ANSIBLE_PACKAGES="ansible"
+LABEL Name=contrail-base-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Base Docker Image for Contrail" Vendor="Juniper Networks"
+
+# Contrail Install Repo; This repo file will removed after contrail
+# installation at the app containers
+COPY contrail-install.repo /etc/yum.repos.d/contrail-install.repo
+
+# Disable all upstream repos inherited from hypervisor
+RUN rm -f /etc/yum.repos.d/redhat.repo
+COPY redhat.repo.alldisabled /etc/yum.repos.d/redhat.repo
+
+# Copy required files to Docker
+COPY python-contrailctl /python-contrailctl
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN echo $CONTRAIL_REPO_URL && \
+    sed -i "s#baseurl=baseurl#baseurl=$CONTRAIL_REPO_URL#" /etc/yum.repos.d/contrail-install.repo && \
+    yum clean all && yum clean expire-cache && \
+    yum repolist
+RUN yum -y install --disablerepo=* --enablerepo=contrail-install-repo \
+      yum-plugin-priorities python-setuptools $ANSIBLE_PACKAGES \
+      iproute net-tools openssh-clients wget tar telnet vim which
+RUN cd /python-contrailctl/; python setup.py install
+ADD $CONTRAIL_ANSIBLE_TAR /
+VOLUME [ "/sys/fs/cgroup" ]
+RUN systemctl set-default multi-user.target
+ENV init /lib/systemd/systemd
+ENTRYPOINT ["/lib/systemd/systemd"]
+CMD ["systemd.unit=multi-user.target"]
+
+RUN yum clean all ; yum clean expire-cache; echo pass

--- a/docker/contrail-base/redhat/contrail-install.repo
+++ b/docker/contrail-base/redhat/contrail-install.repo
@@ -1,0 +1,6 @@
+[contrail-install-repo]
+name=contrail-install-repo
+baseurl=baseurl
+enabled=1
+priority=1
+gpgcheck=0

--- a/docker/contrail-base/redhat/redhat.repo.alldisabled
+++ b/docker/contrail-base/redhat/redhat.repo.alldisabled
@@ -1,0 +1,2713 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+
+[rhel-7-server-dotnet-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/dotnet/1/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = dotNET on RHEL Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/v2vwin/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/6.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rh-common/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/supplementary/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/fast-datapath/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/6.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhs-client/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/v2vwin/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/cert/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/$releasever/$basearch/rhscl/1/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Debug RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-devtools/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-devtools/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/6.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/6.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhscl/1/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhn-tools/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/5.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/dotnet/1/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = dotNET on RHEL RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-devtools/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/6.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-x86_64-server-7-mrg-messaging-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-inst/6.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-x86_64-server-7-mrg-messaging-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/x86_64/source/SRPMS
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/5.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/$releasever/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Source RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/cert/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Certification (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/cert/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Certification (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhscl/1/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/5.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rh-common/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/v2vwin/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/highavailability/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhn-tools/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/6.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-inst/6.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/5.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/$releasever/$basearch/rhscl/1/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhs-client/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/5.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/5.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/fast-datapath/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/nfv/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = dotNET on RHEL Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhs-client/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/nfv/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/highavailability/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/supplementary/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-x86_64-server-7-mrg-messaging-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/cert/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification Beta (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/fast-datapath/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/nfv/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-inst/6.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1

--- a/docker/contrail-base/redhat7/Dockerfile
+++ b/docker/contrail-base/redhat7/Dockerfile
@@ -1,0 +1,48 @@
+FROM contrail-base-os-images/rhel-7.2
+MAINTAINER Juniper Contrail <contrail@juniper.net>
+ARG CONTRAIL_REPO_URL
+ARG CONTRAIL_ANSIBLE_TAR
+ARG CONTRAIL_VERSION
+ARG OS
+ENV ANSIBLE_INVENTORY="all-in-one"
+ARG ANSIBLE_PACKAGES="ansible"
+LABEL Name=contrail-base-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Base Docker Image for Contrail" Vendor="Juniper Networks"
+
+# Contrail Install Repo; This repo file will removed after contrail
+# installation at the app containers
+COPY contrail-install.repo /etc/yum.repos.d/contrail-install.repo
+
+# Disable all upstream repos inherited from hypervisor
+RUN rm -f /etc/yum.repos.d/redhat.repo
+COPY redhat.repo.alldisabled /etc/yum.repos.d/redhat.repo
+
+# Copy required files to Docker
+COPY python-contrailctl /python-contrailctl
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN echo $CONTRAIL_REPO_URL && \
+    sed -i "s#baseurl=baseurl#baseurl=$CONTRAIL_REPO_URL#" /etc/yum.repos.d/contrail-install.repo && \
+    yum clean all && yum clean expire-cache && \
+    yum repolist
+RUN yum -y install --disablerepo=* --enablerepo=contrail-install-repo \
+      yum-plugin-priorities python-setuptools $ANSIBLE_PACKAGES \
+      iproute net-tools openssh-clients wget tar telnet vim which
+RUN cd /python-contrailctl/; python setup.py install
+ADD $CONTRAIL_ANSIBLE_TAR /
+VOLUME [ "/sys/fs/cgroup" ]
+RUN systemctl set-default multi-user.target
+ENV init /lib/systemd/systemd
+ENTRYPOINT ["/lib/systemd/systemd"]
+CMD ["systemd.unit=multi-user.target"]
+
+RUN yum clean all ; yum clean expire-cache; echo pass

--- a/docker/contrail-base/redhat7/contrail-install.repo
+++ b/docker/contrail-base/redhat7/contrail-install.repo
@@ -1,0 +1,6 @@
+[contrail-install-repo]
+name=contrail-install-repo
+baseurl=baseurl
+enabled=1
+priority=1
+gpgcheck=0

--- a/docker/contrail-base/redhat7/redhat.repo.alldisabled
+++ b/docker/contrail-base/redhat7/redhat.repo.alldisabled
@@ -1,0 +1,2713 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+
+[rhel-7-server-dotnet-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/dotnet/1/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = dotNET on RHEL Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/v2vwin/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/6.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rh-common/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/supplementary/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/fast-datapath/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/6.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhs-client/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/v2vwin/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/cert/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/$releasever/$basearch/rhscl/1/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Debug RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-devtools/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-devtools/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/6.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/6.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhscl/1/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhn-tools/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.7-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/5.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/dotnet/1/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = dotNET on RHEL RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-calamari-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-devtools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-devtools/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Developer Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-fastrack-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Fastrack (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/6.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-x86_64-server-7-mrg-messaging-2-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-inst/6.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-x86_64-server-7-mrg-messaging-2-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-fastrack-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Fastrack (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/atomic/7/x86_64/source/SRPMS
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/5.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/$releasever/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Source RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhscl/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Software Collections Beta RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-optools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-optools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Operational Tools Beta for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/cert/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Certification (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.2-installer-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta for Server 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/2/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/cert/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Certification (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.3/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhscl/1/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Debug RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/2/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-extras-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/extras/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Extras (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhscl/1/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/5.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rh-common/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-mon-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-v2vwin-1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/v2vwin/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Virt V2V Tool for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-beta-cts-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/openstack-cts/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat OpenStack Beta Certification Test Suite for Server 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/9/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/highavailability/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/10/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rh-common-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rh-common/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - RH Common (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-calamari-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-calamari/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Calamari 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-2-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/2/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 2 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-optools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/10/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 Operational Tools for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhn-tools/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-cts-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/6.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Certification Test Suite (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-10-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/10/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 10 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-installer/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Installer 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-inst/6.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/5.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-server-rhscl-7-eus-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/eus/rhel/server/7/$releasever/$basearch/rhscl/1/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 RHEL 7 Server EUS
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/supplementary/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhs-client/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.6-for-rhel-7-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.6/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.6 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/5.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-5.0-cts-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-cts/5.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 5.0 for RHEL 7 Certification Test Suite (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/fast-datapath/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/7.0/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/highavailability/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhn-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhn-tools/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = RHN Tools for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-tools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-tools/1.3/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage Tools 1.3 for Red Hat Enterprise Linux 7 Server (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/nfv/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/9/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-htb-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/htb/rhel/server/7/$basearch/fast-datapath/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath Beta (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-beta-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = dotNET on RHEL Beta Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-tools-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/8/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 Tools for RHEL 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6.1-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/sat-tools/6.1/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6.1 (for RHEL 7 Server) (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-tools-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-tools/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Tools 7.0 for Red Hat Enterprise Linux 7 Server (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-dotnet-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/dotnet/1/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = dotNET on RHEL Source RPMs for Red Hat Enterprise Linux 7 Server
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rh-gluster-3-client-for-rhel-7-server-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/rhs-client/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Storage Native Client for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/nfv/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-fastrack-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/fastrack/rhel/server/7/$basearch/highavailability/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) - Fastrack (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-director-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 director for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-ha-for-rhel-7-server-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/highavailability/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux High Availability (for RHEL 7 Server) (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-director-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-director/7.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 director for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/supplementary/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-atomic-host-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/atomic/7/7Server/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Atomic Host (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-9-optools-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-optools/9/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 9 Operational Tools for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/optional/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-x86_64-server-7-mrg-messaging-2-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/7Server/$basearch/mrg-m/2/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise MRG Messaging 2 for RHEL 7 (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-satellite-tools-6-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/sat-tools/6/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Satellite Tools 6 Beta (for RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[cf-me-5.5-for-rhel-7-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/cf-me/server/5.5/$basearch/source/SRPMS
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat CloudForms Management Engine 5.5 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/8/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-rhceph-1.3-mon-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/ceph-mon/1.3/debug
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Ceph Storage MON 1.3 for Red Hat Enterprise Linux 7 Server (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-supplementary-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/supplementary/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Supplementary (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-cert-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/cert/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Certification Beta (for RHEL 7 Server)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-fast-datapath-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/fast-datapath/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux Fast Datapath (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-beta-debug-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/debug
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server Beta (Debug RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-nfv-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/nfv/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux for Real Time for NFV (RHEL 7 Server) (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-7.0-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/7.0/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat Enterprise Linux OpenStack Platform 7.0 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-6.0-installer-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack-inst/6.0/os
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack 6.0 for RHEL 7 Platform Installer (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-optional-beta-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/beta/rhel/server/7/$basearch/optional/os
+ui_repoid_vars = basearch
+sslverify = 1
+name = Red Hat Enterprise Linux 7 Server - Optional Beta (RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-beta,file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1
+
+[rhel-7-server-openstack-8-source-rpms]
+metadata_expire = 86400
+sslclientcert = /etc/pki/entitlement-host/4327290096011685173.pem
+baseurl = https://cdn.redhat.com/content/dist/rhel/server/7/$releasever/$basearch/openstack/8/source/SRPMS
+ui_repoid_vars = releasever basearch
+sslverify = 1
+name = Red Hat OpenStack Platform 8 for RHEL 7 (Source RPMs)
+sslclientkey = /etc/pki/entitlement-host/4327290096011685173-key.pem
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+enabled = 0
+sslcacert = /etc/rhsm-host/ca/redhat-uep.pem
+gpgcheck = 1

--- a/docker/contrail-repo/redhat/Dockerfile
+++ b/docker/contrail-repo/redhat/Dockerfile
@@ -1,0 +1,20 @@
+FROM contrail-base-os-images/rhel-7.2
+MAINTAINER Juniper Contrail <contrail@juniper.net>
+ARG CONTRAIL_INSTALL_PACKAGE_TAR_URL
+ARG CONTRAIL_REPO_PORT
+ARG CONTRAIL_VERSION
+ARG OS
+ARG http_proxy
+ARG https_proxy
+ARG SSHPASS
+ARG SSHUSER=root
+LABEL Name=contrail-repo-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Repo" Vendor="Juniper Networks"
+
+COPY install_repo.sh /
+RUN bash -x /install_repo.sh
+RUN echo "echo \"Repo is up on port $CONTRAIL_REPO_PORT, Create repo file with baseurl=http://<ip of repo>:$CONTRAIL_REPO_PORT \"; cd /opt/contrail/contrail_install_repo && python -m SimpleHTTPServer $CONTRAIL_REPO_PORT" > /entrypoint.sh; \
+    chmod +x /entrypoint.sh
+EXPOSE $CONTRAIL_REPO_PORT
+ENTRYPOINT /entrypoint.sh

--- a/docker/contrail-repo/redhat/install_repo.sh
+++ b/docker/contrail-repo/redhat/install_repo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+function try_wget () {
+    wget -q --spider $1;
+    return $?
+}
+
+xtrace_status() {
+  set | grep -q SHELLOPTS=.*:xtrace
+  return $?
+}
+
+yum_install="yum install -y "
+
+if [[ -z $CONTRAIL_INSTALL_PACKAGE_TAR_URL ]]; then
+    echo "ERROR CONTRAIL_INSTALL_PACKAGE_TAR_URL undefined"
+    exit 1
+fi
+
+if [[ $CONTRAIL_INSTALL_PACKAGE_TAR_URL =~ ^http[s]*:// ]]; then
+    $yum_install wget tar
+    if try_wget $CONTRAIL_INSTALL_PACKAGE_TAR_URL; then
+       wget -q $CONTRAIL_INSTALL_PACKAGE_TAR_URL -O /tmp/contrail-install-packages.tar.gz
+    else
+        echo "ERROR! $CONTRAIL_INSTALL_PACKAGE_TAR_URL is not accessible"
+        exit 1
+    fi
+elif [[ $CONTRAIL_INSTALL_PACKAGE_TAR_URL =~ ^ssh:// ]]; then
+    server=` echo $CONTRAIL_INSTALL_PACKAGE_TAR_URL | sed 's/ssh:\/\///;s|\/.*||'`
+    path=`echo $CONTRAIL_INSTALL_PACKAGE_TAR_URL |sed -r 's#ssh://[a-zA-Z0-9_\.\-]+##'`
+    export SSHUSER=${SSHUSER:-root}
+    if xtrace_status; then
+        set +x
+        xtrace=1
+    fi
+    export SSHPASS=${SSHPASS:-passwd}
+    [[ -n $xtrace ]] && set -x
+    $yum_install sshpass openssh-clients tar
+    sshpass -e scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${SSHUSER}@${server}:${path} /tmp/contrail-install-packages.tar.gz
+else
+    echo "ERROR, Unknown url format, only http[s], ssh supported"
+    exit 1
+fi
+
+mkdir -p /opt/contrail/contrail_install_repo
+(cd /opt/contrail/contrail_install_repo && tar -xzf /tmp/contrail-install-packages.tar.gz)
+rm -f /tmp/contrail-install-packages.tar.gz

--- a/docker/contrail-repo/redhat7/Dockerfile
+++ b/docker/contrail-repo/redhat7/Dockerfile
@@ -1,0 +1,20 @@
+FROM contrail-base-os-images/rhel-7.2
+MAINTAINER Juniper Contrail <contrail@juniper.net>
+ARG CONTRAIL_INSTALL_PACKAGE_TAR_URL
+ARG CONTRAIL_REPO_PORT
+ARG CONTRAIL_VERSION
+ARG OS
+ARG http_proxy
+ARG https_proxy
+ARG SSHPASS
+ARG SSHUSER=root
+LABEL Name=contrail-repo-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Repo" Vendor="Juniper Networks"
+
+COPY install_repo.sh /
+RUN bash -x /install_repo.sh
+RUN echo "echo \"Repo is up on port $CONTRAIL_REPO_PORT, Create repo file with baseurl=http://<ip of repo>:$CONTRAIL_REPO_PORT \"; cd /opt/contrail/contrail_install_repo && python -m SimpleHTTPServer $CONTRAIL_REPO_PORT" > /entrypoint.sh; \
+    chmod +x /entrypoint.sh
+EXPOSE $CONTRAIL_REPO_PORT
+ENTRYPOINT /entrypoint.sh

--- a/docker/contrail-repo/redhat7/install_repo.sh
+++ b/docker/contrail-repo/redhat7/install_repo.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+function try_wget () {
+    wget -q --spider $1;
+    return $?
+}
+
+xtrace_status() {
+  set | grep -q SHELLOPTS=.*:xtrace
+  return $?
+}
+
+yum_install="yum install -y "
+
+if [[ -z $CONTRAIL_INSTALL_PACKAGE_TAR_URL ]]; then
+    echo "ERROR CONTRAIL_INSTALL_PACKAGE_TAR_URL undefined"
+    exit 1
+fi
+
+if [[ $CONTRAIL_INSTALL_PACKAGE_TAR_URL =~ ^http[s]*:// ]]; then
+    $yum_install wget tar
+    if try_wget $CONTRAIL_INSTALL_PACKAGE_TAR_URL; then
+       wget -q $CONTRAIL_INSTALL_PACKAGE_TAR_URL -O /tmp/contrail-install-packages.tar.gz
+    else
+        echo "ERROR! $CONTRAIL_INSTALL_PACKAGE_TAR_URL is not accessible"
+        exit 1
+    fi
+elif [[ $CONTRAIL_INSTALL_PACKAGE_TAR_URL =~ ^ssh:// ]]; then
+    server=` echo $CONTRAIL_INSTALL_PACKAGE_TAR_URL | sed 's/ssh:\/\///;s|\/.*||'`
+    path=`echo $CONTRAIL_INSTALL_PACKAGE_TAR_URL |sed -r 's#ssh://[a-zA-Z0-9_\.\-]+##'`
+    export SSHUSER=${SSHUSER:-root}
+    if xtrace_status; then
+        set +x
+        xtrace=1
+    fi
+    export SSHPASS=${SSHPASS:-passwd}
+    [[ -n $xtrace ]] && set -x
+    $yum_install sshpass openssh-clients tar
+    sshpass -e scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${SSHUSER}@${server}:${path} /tmp/contrail-install-packages.tar.gz
+else
+    echo "ERROR, Unknown url format, only http[s], ssh supported"
+    exit 1
+fi
+
+mkdir -p /opt/contrail/contrail_install_repo
+(cd /opt/contrail/contrail_install_repo && tar -xzf /tmp/contrail-install-packages.tar.gz)
+rm -f /tmp/contrail-install-packages.tar.gz

--- a/docker/controller/redhat/Dockerfile.j2
+++ b/docker/controller/redhat/Dockerfile.j2
@@ -1,0 +1,22 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-controller-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Controller" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c controller -F -t package
+RUN contrailctl config sync -c controller -F -t install
+EXPOSE 53 68 123 179 2181 4369 \
+       5269 5672 5997 5998 \
+       8080 8082 8083 8084 8087 8088 8092 8093 8094 8096 8100 8101 8103 8143 8443 8444 \
+       9092 9160
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass

--- a/docker/controller/redhat/redhat.repo.empty
+++ b/docker/controller/redhat/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/controller/redhat7/Dockerfile.j2
+++ b/docker/controller/redhat7/Dockerfile.j2
@@ -1,0 +1,22 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-controller-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail Controller" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c controller -F -t package
+RUN contrailctl config sync -c controller -F -t install
+EXPOSE 53 68 123 179 2181 4369 \
+       5269 5672 5997 5998 \
+       8080 8082 8083 8084 8087 8088 8092 8093 8094 8096 8100 8101 8103 8143 8443 8444 \
+       9092 9160
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass

--- a/docker/controller/redhat7/redhat.repo.empty
+++ b/docker/controller/redhat7/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/lb/redhat/Dockerfile.j2
+++ b/docker/lb/redhat/Dockerfile.j2
@@ -1,0 +1,18 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-lb-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail LB" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c lb -F -t install
+EXPOSE 5998 8081 8082 9696
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass

--- a/docker/lb/redhat/redhat.repo.empty
+++ b/docker/lb/redhat/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/docker/lb/redhat7/Dockerfile.j2
+++ b/docker/lb/redhat7/Dockerfile.j2
@@ -1,0 +1,18 @@
+FROM contrail-base-redhat:{{ contrail_version }}
+ARG CONTRAIL_VERSION
+ARG OS
+LABEL Name=contrail-lb-$OS \
+      Version="$CONTRAIL_VERSION" \
+      Description="Dockerimage for Contrail LB" Vendor="Juniper Networks"
+
+RUN contrailctl config sync -c lb -F -t install
+EXPOSE 5998 8081 8082 9696
+
+# Copy Empty repo file so will be overridden by hypervisor's subscription
+COPY redhat.repo.empty /etc/yum.repos.d/redhat.repo
+
+# Repo cleanup
+RUN [ -f /etc/yum.repos.d/contrail-install.repo ] && \
+      rm -f /etc/yum.repos.d/contrail-install.repo ; \
+    yum clean all ; yum clean expire-cache ;\
+    echo pass

--- a/docker/lb/redhat7/redhat.repo.empty
+++ b/docker/lb/redhat7/redhat.repo.empty
@@ -1,0 +1,11 @@
+#
+# Certificate-Based Repositories
+# Managed by (rhsm) subscription-manager
+#
+# *** This file is auto-generated.  Changes made here will be over-written. ***
+# *** Use "subscription-manager repo-override --help" if you wish to make changes. ***
+#
+# If this file is empty and this system is subscribed consider
+# a "yum repolist" to refresh available repos
+#
+

--- a/tools/python-contrailctl/requirements.txt
+++ b/tools/python-contrailctl/requirements.txt
@@ -1,3 +1,1 @@
 ansible
-ConfigParser
-


### PR DESCRIPTION
*** Just Review. Do not merge ***
This commit would need to be tested with build scripts.

1) Removed Dependency for Configparser from python-contrailctl
2) Redhat specific Dockerfiles and support files.