### PR TITLE
Use ip to detect CONTRAIL_REPO_IP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifndef CONTRAIL_SKU
 endif
 
 ifndef CONTRAIL_REPO_IP
-	export CONTRAIL_REPO_IP := $(shell ifconfig docker0 | awk '/inet.addr:/ {print $$2}' | cut -f2 -d:)
+	export CONTRAIL_REPO_IP := $(shell ip a l docker0 | awk '/inet / {print $$2}' | cut -f1 -d'/')
 endif
 
 ifndef SSHUSER


### PR DESCRIPTION
ifconfig is not available on centos, and thus failing container build on
centos build node.