### PR TITLE
Support Kubernetes manifests and helm chart for contrail

### DIFF
--- a/kubernetes/helm/contrail/.helmignore
+++ b/kubernetes/helm/contrail/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kubernetes/helm/contrail/Chart.yaml
+++ b/kubernetes/helm/contrail/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for contrail
+name: contrail
+version: 0.1.0

--- a/kubernetes/helm/contrail/templates/NOTES.txt
+++ b/kubernetes/helm/contrail/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Contrail controller and agent pod setup

--- a/kubernetes/helm/contrail/templates/_helpers.tpl
+++ b/kubernetes/helm/contrail/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/kubernetes/helm/contrail/templates/agent.yaml
+++ b/kubernetes/helm/contrail/templates/agent.yaml
@@ -1,0 +1,90 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: kube-system
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Values.contrailVersion }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "kubeadm.alpha.kubernetes.io/role",
+                        "operator": "NotIn",
+                        "values": ["master"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        scheduler.alpha.kubernetes.io/tolerations: >
+          [
+            {
+              "key":"dedicated",
+              "value":"master",
+              "effect":"NoSchedule"
+            },
+           {
+              "key":"CriticalAddonsOnly",
+              "operator":"Exists"
+           }
+          ]
+
+    spec:
+      hostNetwork: true
+      containers:
+      - name: contrail-agent
+        image: "{{ .Values.imageRepo }}/{{ default "contrail-agent" .Values.agentImageName }}-{{ .Values.osRelease }}:{{ .Values.contrailVersion }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: etc-contrailctl
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /host/usr_lib
+          name: usr-lib
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /host/etc_cni
+          name: etc-cni
+      volumes:
+      - name: etc-contrailctl
+        configMap:
+          name: contrail-agent-config
+          items:
+          - key: agent-config
+            path: agent.conf
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: usr-lib
+        hostPath:
+          path: /usr/lib
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni

--- a/kubernetes/helm/contrail/templates/configmap.yaml
+++ b/kubernetes/helm/contrail/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: kube-system
+data:
+  agent-config: |
+    [GLOBAL]
+    vrouter_physical_interface = {{ .Values.vrouterPhysicalInterface | quote }}
+    controller_list = {{ .Values.controllerList }}
+    analytics_list = {{ .Values.analyticsList }}

--- a/kubernetes/helm/contrail/templates/controller.yaml
+++ b/kubernetes/helm/contrail/templates/controller.yaml
@@ -1,0 +1,69 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ template "fullname" . }}
+  namespace: kube-system
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Values.contrailVersion }}"
+spec:
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "kubeadm.alpha.kubernetes.io/role",
+                        "operator": "In",
+                        "values": ["master"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        scheduler.alpha.kubernetes.io/tolerations: >
+          [
+            {
+              "key":"dedicated",
+              "value":"master",
+              "effect":"NoSchedule"
+            },
+           {
+              "key":"CriticalAddonsOnly",
+              "operator":"Exists"
+           }
+          ]
+    spec:
+      hostNetwork: true
+      containers:
+      - name: contrail-controller
+        image: "{{ .Values.imageRepo }}/{{ default "contrail-controller" .Values.controllerImageName }}-{{ .Values.osRelease }}:{{ .Values.contrailVersion }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        securityContext:
+          privileged: true
+      - name: contrail-analyticsdb
+        image: "{{ .Values.imageRepo }}/{{ default "contrail-analyticsdb" .Values.analyticsdbImageName }}-{{ .Values.osRelease }}:{{ .Values.contrailVersion }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        securityContext:
+          privileged: true
+      - name: contrail-analytics
+        image: "{{ .Values.imageRepo }}/{{ default "contrail-analytics" .Values.analyticsImageName }}-{{ .Values.osRelease }}:{{ .Values.contrailVersion }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        securityContext:
+          privileged: true
+      - name: contrail-kube-manager
+        image: "{{ .Values.imageRepo }}/{{ default "contrail-kube-manager" .Values.kubeManagerImageName }}-{{ .Values.osRelease }}:{{ .Values.contrailVersion }}"
+        imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+        securityContext:
+          privileged: true

--- a/kubernetes/helm/contrail/values.yaml
+++ b/kubernetes/helm/contrail/values.yaml
@@ -1,0 +1,37 @@
+# Default values for contrail.
+# contrailVersion
+contrailVersion: 4.0.0.0-3042
+
+# osRelease - operating system release
+# ubuntu 14.04 - u14.04
+# ubuntu 16.04 - u16.04
+# centos 7.1 - c7.1
+# centos 7.2 - c7.2
+osRelease: u16.04
+
+# image repository, pull policy etc
+imageRepo: 10.84.34.155:5000
+
+#
+# Agent configurations
+#
+# vrouterPhysicalInterface - physical interface to use for vrouter
+vrouterPhysicalInterface: eth0
+
+# controllerList - list of controller nodes
+controllerList: [192.168.0.109]
+
+# analyticsList - list of analytics nodes
+analyticsList: [192.168.0.109]
+
+## Specify a imagePullPolicy: 'Always' if imageTag is 'latest', else set to 'IfNotPresent'.
+## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+##
+imagePullPolicy: IfNotPresent
+
+# container image names
+# controllerImageName: contrail-controller
+# analyticsImageName: contrail-analytics
+# analyticsdbImageName: contrail-analyticsdb
+# kubeManagerImageName: contrail-kube-manager
+# agentImageName: contrail-agent

--- a/kubernetes/manifests/contrail.yaml
+++ b/kubernetes/manifests/contrail.yaml
@@ -1,0 +1,165 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contrail-agent-config
+  namespace: kube-system
+data:
+  agent-config: |
+    [GLOBAL]
+    copy_vrouter_module = False
+    compile_vrouter_module = True
+    vrouter_physical_interface = eth0
+    controller_list = ["192.168.0.109"]
+    analytics_list = ["192.168.0.109"]
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-controller
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-controller
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "kubeadm.alpha.kubernetes.io/role",
+                        "operator": "In",
+                        "values": ["master"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        scheduler.alpha.kubernetes.io/tolerations: >
+          [
+            {
+              "key":"dedicated",
+              "value":"master",
+              "effect":"NoSchedule"
+            },
+           {
+              "key":"CriticalAddonsOnly",
+              "operator":"Exists"
+           }
+          ]
+    spec:
+      hostNetwork: true
+      containers:
+      - name: contrail-kube-manager
+        image: 10.84.34.155:5000/contrail-kube-manager-u16.04:4.0.0.0-3042
+        securityContext:
+          privileged: true
+      - name: contrail-controller
+        image: 10.84.34.155:5000/contrail-controller-u16.04:4.0.0.0-3042
+        securityContext:
+          privileged: true
+      - name: contrail-analytics
+        image: 10.84.34.155:5000/contrail-analytics-u16.04:4.0.0.0-3042
+        securityContext:
+          privileged: true
+      - name: contrail-analytics-db
+        image: 10.84.34.155:5000/contrail-analyticsdb-u16.04:4.0.0.0-3042
+        securityContext:
+          privileged: true
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: contrail-agent
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        app: contrail-agent
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/affinity: >
+          {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                  {
+                    "matchExpressions": [
+                      {
+                        "key": "kubeadm.alpha.kubernetes.io/role",
+                        "operator": "NotIn",
+                        "values": ["master"]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        scheduler.alpha.kubernetes.io/tolerations: >
+          [
+            {
+              "key":"dedicated",
+              "value":"master",
+              "effect":"NoSchedule"
+            },
+           {
+              "key":"CriticalAddonsOnly",
+              "operator":"Exists"
+           }
+          ]
+
+    spec:
+      hostNetwork: true
+      containers:
+      - name: contrail-agent
+        image: 10.84.34.155:5000/contrail-agent-u16.04:4.0.0.0-3042-dev
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/contrailctl
+          name: etc-contrailctl
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /usr/src
+          name: usr-src
+        - mountPath: /host/usr_lib
+          name: usr-lib
+        - mountPath: /host/opt_cni_bin
+          name: opt-cni-bin
+        - mountPath: /host/etc_cni
+          name: etc-cni
+      volumes:
+      - name: etc-contrailctl
+        configMap:
+          name: contrail-agent-config
+          items:
+          - key: agent-config
+            path: agent.conf
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: usr-src
+        hostPath:
+          path: /usr/src
+      - name: usr-lib
+        hostPath:
+          path: /usr/lib
+      - name: opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: etc-cni
+        hostPath:
+          path: /etc/cni


### PR DESCRIPTION
This is the initial patch to support kubernetes manifests and helm chart
for contrail services to be deployed as pods

* Added helm contrail chart
* Added pod manifests for contrail