### PR TITLE
Fix Makefile for pre-supplied ansible artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,12 +139,12 @@ $(CONTRAIL_BASE_TAR): ansible-internal contrail-repo
 	@touch $@
 
 $(CONTRAIL_ANSIBLE_TAR):
-ifdef $(CONTRAIL_ANSIBLE_ARTIFACT)
-	if [[ -f $(CONTRAIL_ANSIBLE_ARTIFACT) ]]; then  \
+ifdef CONTRAIL_ANSIBLE_ARTIFACT
+	if [ -f $(CONTRAIL_ANSIBLE_ARTIFACT) ]; then  \
 		cp -f $(CONTRAIL_ANSIBLE_ARTIFACT) $(CONTRAIL_ANSIBLE_TAR) ;\
 	else \
-		@echo "No artifact found, getting the code from git repo" ; \
-		$(eval BUILD_CONTRAIL_ANSIBLE_TAR := yes) ; \
+		@echo "ERROR: ansible artifact not found: $(CONTRAIL_ANSIBLE_ARTIFACT)" ; \
+		@exit 1; \
 	fi
 else
 	$(eval BUILD_CONTRAIL_ANSIBLE_TAR := yes)


### PR DESCRIPTION
The Makefile code that accepts CONTRAIL_ANSIBLE_ARTIFACT has not been
tested or used, and some immediate breakage that needs fixing:
- ifdef needs a var/macro name
- gnu make uses /bin/sh, so avoid bash extended conditional syntax
- one cannot have gnu make $(eval ... ) within if/then of recipes and
  expect that they will be executed only conditionally.
  Instead, gnu make expands it within the recipe, always. Oops.