### PR TITLE
Changing default of osRelease to new format

### DIFF
--- a/kubernetes/helm/contrail/values.yaml
+++ b/kubernetes/helm/contrail/values.yaml
@@ -4,11 +4,10 @@
 # contrailVersion:
 
 # osRelease - operating system release
-# ubuntu 14.04 - u14.04
-# ubuntu 16.04 - u16.04
-# centos 7.1 - c7.1
-# centos 7.2 - c7.2
-osRelease: u16.04
+# ubuntu 14.04 - ubuntu14.04
+# ubuntu 16.04 - ubuntu16.04
+# centos 7.x - centos7
+osRelease: ubuntu16.04
 
 # image repository, pull policy etc
 imageRepo: 10.84.34.155:5000


### PR DESCRIPTION
Partial-Bug #1665227

There is a PR (#170) to change the container image names to new format that
is mentioned in the bug refered above. This patch is to make
corresponding change in helm to support helm to new container name
format.

NOTE: after this change merged, users will need to change osRelease in
values.yml (or custom values file) to older format in order to work with
older builds.

REF: https://bugs.launchpad.net/juniperopenstack/+bug/1665227